### PR TITLE
Removing Org ID from response generation

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -12,12 +12,10 @@ module Api
             end
 
             def create 
-                organisation = Organisation.new(organisation_params)
-
+                organisation = Organisation.new(PPON_ID: generate_specific_ppon_id(Organisation.count+1))
                 if organisation.save
-                    random_string = SecureRandom.alphanumeric(8).upcase
-                    organisation.update(PPON_ID: random_string)
                     render json: organisation.PPON_ID, status: :ok
+                    organisation.save
                 else
                     render json: {status: 'ERROR', message: 'Organisation not saved', data:organisation.errors}, status: :unprocessable_entity
                 end
@@ -28,6 +26,12 @@ module Api
 
             def organisation_params
                 params.permit(:id)
+            end
+
+            def generate_specific_ppon_id(index)
+                result = %x(python3 ppon_id_script.py #{index} 2>&1)
+                puts "Generating PPON ID, at index: #{index}:  #{result}"
+                return result.to_s
             end
         end
     end 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,6 @@
 class Organisation < ApplicationRecord
 
-    # validates :PPON_ID, presence: true, uniqueness: true
-    # validates_format_of :PPON_ID, :with => /[A-Za-z]{2}\d{4}[A-Za-z]{2}\z/
+    validates :PPON_ID, presence: true, uniqueness: true
+    validates_format_of :PPON_ID, :with => /[A-Za-z]{2}\d{4}[A-Za-z]{2}\d\z/
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 Organisation.destroy_all
 Organisation.reset_pk_sequence
 Organisation.create!([{
-    PPON_ID: "AA1111AA",
+    PPON_ID: "AA1111AA1",
 }])
 
 p "Created #{Organisation.count} Organisations"


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/PPG-51

Following the choice to remove ORG_ID from the database, the response generation has been reworked to i) not ingest ORG_ID as part of POST request ii) (therefore) to not persist ORG_ID within the mircroservice