### PR TITLE
Remove updated_at column from database

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -210,6 +212,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.1-arm64-darwin)
+    sqlite3 (1.6.1-x86_64-darwin)
     sqlite3 (1.6.1-x86_64-linux)
     thor (1.2.1)
     timeout (0.3.2)
@@ -223,6 +226,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/db/migrate/20230320151644_remove_updated_at_from_organisation.rb
+++ b/db/migrate/20230320151644_remove_updated_at_from_organisation.rb
@@ -1,0 +1,5 @@
+class RemoveUpdatedAtFromOrganisation < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :organisations, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_15_114134) do
+ActiveRecord::Schema.define(version: 2023_03_20_151644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 2023_03_15_114134) do
   create_table "organisations", force: :cascade do |t|
     t.string "ppon_id"
     t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
 end


### PR DESCRIPTION
Added migration file to remove "updated_at" attribute from schema. 